### PR TITLE
Action(wheel): build wheels when pushing/creating pr to branch release/build-wheel

### DIFF
--- a/.github/workflows/build_wheels_manually.yml
+++ b/.github/workflows/build_wheels_manually.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Build wheel
         run: |
           chmod +x dev/build-wheels.sh
+          chmod +x dev/lint-python.sh
           bash dev/build-wheels.sh
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build_wheels_manually.yml
+++ b/.github/workflows/build_wheels_manually.yml
@@ -1,0 +1,99 @@
+name: Build and Publish Wheels
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - release/build-wheel
+  pull_request:
+    branches:
+      - release/build-wheel
+jobs:
+  build_wheels_linux:
+    name: Build python wheels on Linux
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install java
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - name: Build wheel
+        run: bash dev/build-wheels.sh
+      - name: Upload wheels as artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheel_ubuntu-20.04
+          path: ./dist/
+
+  build_wheels_mac:
+    name: Build python wheel for ${{ matrix.python }}-Mac
+    runs-on: ${{ matrix.buildplat[0] }}
+    strategy:
+      matrix:
+        buildplat:
+          - [macos-latest, macosx_*]
+        python: ["cp38", "cp39", "cp310", "cp311"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install java
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      # Used to push the built wheels
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.15.0
+        env:
+          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.python }}-${{ startsWith(matrix.buildplat[1], 'macosx') && 'macosx' || matrix.buildplat[1] }}
+          path: ./wheelhouse/*.whl
+
+
+  build_wheels_win:
+    name: Build python wheel for ${{ matrix.python }}-Windows
+    runs-on: ${{ matrix.buildplat[0] }}
+    strategy:
+      matrix:
+        buildplat:
+          - [windows-latest, win_amd64]
+        python: ["cp38", "cp39", "cp310", "cp311"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install java
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+      - name: Check Java version
+        run: |
+          java -version
+          echo "JAVA_HOME=$(which java)" >> $GITHUB_ENV
+          echo $JAVA_HOME
+
+      # Used to push the built wheels
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.16.5
+        env:
+          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.python }}-${{ startsWith(matrix.buildplat[1], 'win') && 'win_amd64' || matrix.buildplat[1] }}
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels_manually.yml
+++ b/.github/workflows/build_wheels_manually.yml
@@ -21,7 +21,9 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - name: Build wheel
-        run: bash dev/build-wheels.sh
+        run: |
+          chmod +x dev/build-wheels.sh
+          bash dev/build-wheels.sh
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/setup.py
+++ b/setup.py
@@ -253,5 +253,6 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         'Operating System :: Unix',
+        'Operating System :: Microsoft :: Windows',
         'Operating System :: MacOS', ],
     ext_modules=extensions)


### PR DESCRIPTION
This workflow builds wheel files for python[3.8, 3.9, 3.10, 3.11] on OS[Windows(amd64), MacOS(amd64), MacOS(x86), Linux]. It will be auto-runned when:
- new push to branch release/build-wheel
- new pr to branch release/build-wheel
- new commits on pr to branch release/wheel
- manually run

The wheel files are uploaded as artifacts and can be downloaded in workflows.